### PR TITLE
Add matic deposit

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -27,7 +27,7 @@ const networks = [
 ]
 // const ran = parseInt((Math.random() * networks.length).toFixed(0))
 // const idx = ran === 0 ? ran : ran - 1
-const idx = 8
+const idx = 1
 
 const App = () => {
   const [open, setOpen] = useState(true)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,6 +7,7 @@ import {
   xDai,
   Avalanche,
   SKALE,
+  MaticTestnet,
   Matic,
   Config
 } from '@huskyfinance/eth-sorbet'
@@ -21,11 +22,12 @@ const networks = [
   xDai,
   Avalanche,
   SKALE,
+  MaticTestnet,
   Matic
 ]
 // const ran = parseInt((Math.random() * networks.length).toFixed(0))
 // const idx = ran === 0 ? ran : ran - 1
-const idx = 7
+const idx = 8
 
 const App = () => {
   const [open, setOpen] = useState(true)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -68,7 +68,6 @@ const App = () => {
     // optional
     checkBalance: true,
     address: userAddress,
-    l1ChainId: 5,
 
     // dapp
     dappLogo: 'https://www.kkbox.com/about/img/app_icons/kkbox_app_icon.png',

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -7,6 +7,7 @@ import {
   xDai,
   Avalanche,
   SKALE,
+  Matic,
   Config
 } from '@huskyfinance/eth-sorbet'
 import React, { useEffect, useState } from 'react'
@@ -19,11 +20,12 @@ const networks = [
   OptimismMainnet,
   xDai,
   Avalanche,
-  SKALE
+  SKALE,
+  Matic
 ]
 // const ran = parseInt((Math.random() * networks.length).toFixed(0))
 // const idx = ran === 0 ? ran : ran - 1
-const idx = 2
+const idx = 7
 
 const App = () => {
   const [open, setOpen] = useState(true)
@@ -66,7 +68,7 @@ const App = () => {
     // optional
     checkBalance: true,
     address: userAddress,
-    l1ChainId: 42,
+    l1ChainId: 5,
 
     // dapp
     dappLogo: 'https://www.kkbox.com/about/img/app_icons/kkbox_app_icon.png',

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -27,7 +27,7 @@ const networks = [
 ]
 // const ran = parseInt((Math.random() * networks.length).toFixed(0))
 // const idx = ran === 0 ? ran : ran - 1
-const idx = 1
+const idx = 7
 
 const App = () => {
   const [open, setOpen] = useState(true)

--- a/src/components/baseContent.tsx
+++ b/src/components/baseContent.tsx
@@ -8,7 +8,7 @@ const useStyles = makeStyles((theme) => ({
     fontWeight: 'bold'
   },
   content: {
-    minHeight: 290,
+    minHeight: 330,
     fontFamily: "'Titillium Web', sans-serif;",
     color: theme.palette.text.primary
   }

--- a/src/components/baseModal.tsx
+++ b/src/components/baseModal.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.background.paper,
     // border: '2px solid #000',
     boxShadow: theme.shadows[5],
-    minWidth: 600,
+    minWidth: 650,
     minHeight: 330
   },
   main: {

--- a/src/components/deposit.tsx
+++ b/src/components/deposit.tsx
@@ -7,7 +7,7 @@ import Button from '@material-ui/core/Button'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import LockIcon from '@material-ui/icons/Lock'
 import { Config } from '../types'
-import { getApproval, approve } from '../utils/basic'
+import { getAllowance, approve } from '../utils/basic'
 
 const useStyles = makeStyles((theme) => ({
   container: {
@@ -71,7 +71,7 @@ export default function DepositToken({
       decimals: number
     }
 
-    getApproval(
+    getAllowance(
       provider,
       token.address,
       config.address,

--- a/src/components/deposit.tsx
+++ b/src/components/deposit.tsx
@@ -56,7 +56,7 @@ export default function DepositToken({
     return config.targetNetwork.l1Token?.address !== undefined
   }, [config])
 
-  const updateApproval = useCallback(() => {
+  const updateAllowance = useCallback(() => {
     if (
       !isTokenDeposit ||
       !config.address ||
@@ -81,10 +81,9 @@ export default function DepositToken({
     })
   }, [isTokenDeposit, config, provider, chainId])
 
-  // update token allowance
   useEffect(() => {
-    updateApproval()
-  }, [updateApproval])
+    updateAllowance()
+  }, [updateAllowance])
 
   // whether user need to approve first
   const needApproval = useMemo(() => {
@@ -103,7 +102,7 @@ export default function DepositToken({
 
     const callback = () => {
       setIsApproving(false)
-      updateApproval()
+      updateAllowance()
     }
 
     try {
@@ -118,7 +117,7 @@ export default function DepositToken({
     } catch (error) {
       setIsApproving(false)
     }
-  }, [config, scaledAmount, provider, updateApproval])
+  }, [config, scaledAmount, provider, updateAllowance])
 
   // deposit function
   const handleDeposit = useCallback(async () => {

--- a/src/components/deposit.tsx
+++ b/src/components/deposit.tsx
@@ -4,6 +4,7 @@ import { ethers, BigNumber } from 'ethers'
 import { makeStyles } from '@material-ui/core/styles'
 import TextField from '@material-ui/core/TextField'
 import Button from '@material-ui/core/Button'
+import CircularProgress from '@material-ui/core/CircularProgress'
 
 import { Config } from '../types'
 
@@ -51,15 +52,19 @@ export default function DepositToken({
       throw new Error('Deposit not implemented')
 
     setIsDepositing(true)
-    await config.targetNetwork.depositNativeToken(
-      provider,
-      scaledAmount.toString(),
-      sender,
-      () => {
-        setIsDepositing(false)
-        depositCallback()
-      }
-    )
+    try {
+      await config.targetNetwork.depositNativeToken(
+        provider,
+        scaledAmount.toString(),
+        sender,
+        () => {
+          setIsDepositing(false)
+          depositCallback()
+        }
+      )
+    } catch (error) {
+      setIsDepositing(false)
+    }
   }, [config, scaledAmount])
 
   return (
@@ -82,7 +87,7 @@ export default function DepositToken({
         color='primary'
         onClick={handleDeposit}
       >
-        Deposit
+        {isDeposting ? <CircularProgress size={20} /> : 'Deposit'}
       </Button>
     </div>
   )

--- a/src/components/deposit.tsx
+++ b/src/components/deposit.tsx
@@ -17,16 +17,19 @@ export default function DepositToken({
   config,
   provider,
   l1Balance,
-  onCorrectL1
+  onCorrectL1,
+  depositCallback
 }: {
   config: Config
   provider: any
   l1Balance: BigNumber
   onCorrectL1: boolean
+  depositCallback: Function
 }) {
   const classes = useStyles()
 
   const [amount, setAmount] = useState(0.1)
+  const [isDeposting, setIsDepositing] = useState(false)
 
   const scaledAmount = useMemo(() => {
     const nativeTokenDecimals = config.targetNetwork.nativeCurrency
@@ -47,10 +50,15 @@ export default function DepositToken({
     if (!config.targetNetwork.depositNativeToken)
       throw new Error('Deposit not implemented')
 
+    setIsDepositing(true)
     await config.targetNetwork.depositNativeToken(
       provider,
       scaledAmount.toString(),
-      sender
+      sender,
+      () => {
+        setIsDepositing(false)
+        depositCallback()
+      }
     )
   }, [config, scaledAmount])
 
@@ -68,7 +76,7 @@ export default function DepositToken({
         onChange={(event) => setAmount(Number(event.target.value))}
       />
       <Button
-        disabled={!onCorrectL1 || !hasSufficientAmount}
+        disabled={!onCorrectL1 || !hasSufficientAmount || isDeposting}
         style={{ height: 40 }}
         variant={amount > 0 ? 'contained' : 'outlined'}
         color='primary'

--- a/src/components/deposit.tsx
+++ b/src/components/deposit.tsx
@@ -104,7 +104,7 @@ export default function DepositToken({
     }
 
     try {
-      approve(
+      await approve(
         provider,
         token.address,
         sender,

--- a/src/components/steps/depositContent.tsx
+++ b/src/components/steps/depositContent.tsx
@@ -103,7 +103,6 @@ export default function DepositContent({
     [chainId, config]
   )
 
-  // TODO: refresh balance after successful deposit
   const content = useMemo(() => {
     return (
       <div>
@@ -131,7 +130,12 @@ export default function DepositContent({
         {bridgeLink && (
           <div>
             Your can deposit more tokens via the{' '}
-            <a target='_blank' href={bridgeLink} rel='noreferrer'>
+            <a
+              style={{ color: 'inherit' }}
+              target='_blank'
+              href={bridgeLink}
+              rel='noreferrer'
+            >
               {' '}
               bridge here
             </a>{' '}

--- a/src/components/steps/depositContent.tsx
+++ b/src/components/steps/depositContent.tsx
@@ -6,6 +6,7 @@ import { ethChains } from '../../constant/networks'
 import { Config } from '../../types'
 import Base from '../baseContent'
 import Deposit from '../deposit'
+import { abis } from '../../contracts'
 
 export default function DepositContent({
   // l2Balance,
@@ -40,10 +41,23 @@ export default function DepositContent({
 
   const updateL1Balance = useCallback(() => {
     if (!config.address || !provider) return
+
     const web3Provider = new ethers.providers.Web3Provider(provider)
-    web3Provider
-      .getBalance(config.address)
-      .then((balance: BigNumber) => setL1Balance(balance))
+    // const isToken = config.targetNet work.l1Token !== undefined
+    if (config.targetNetwork.l1Token) {
+      const token = new ethers.Contract(
+        config.targetNetwork.l1Token?.address,
+        abis.erc20,
+        web3Provider
+      )
+      token
+        .balanceOf(config.address)
+        .then((balance: BigNumber) => setL1Balance(balance))
+    } else {
+      web3Provider
+        .getBalance(config.address)
+        .then((balance: BigNumber) => setL1Balance(balance))
+    }
   }, [provider, config, chainId])
 
   // update L1 balance
@@ -108,7 +122,12 @@ export default function DepositContent({
       <div>
         {onCorrectL1 ? (
           <div>
-            Balance on {network}: {ethers.utils.formatUnits(l1Balance, 18)} ETH
+            Balance on {network}:{' '}
+            {ethers.utils.formatUnits(
+              l1Balance,
+              config.targetNetwork.l1Token?.decimals || 18
+            )}{' '}
+            {config.targetNetwork.l1Token?.symbol || 'ETH'}
           </div>
         ) : (
           config.targetNetwork.l1chainId && (
@@ -143,7 +162,7 @@ export default function DepositContent({
           </div>
         )}
         {/* only shows deposit input if the funciton is provided */}
-        {config.targetNetwork.depositNativeToken && (
+        {config.targetNetwork.depositETH && (
           <div>
             <Deposit
               config={config}

--- a/src/components/steps/depositContent.tsx
+++ b/src/components/steps/depositContent.tsx
@@ -40,7 +40,12 @@ export default function DepositContent({
   }, [updateL2Balance])
 
   const updateL1Balance = useCallback(() => {
-    if (!config.address || !provider) return
+    if (
+      !config.address ||
+      !provider ||
+      chainId !== config.targetNetwork.l1chainId
+    )
+      return
 
     const web3Provider = new ethers.providers.Web3Provider(provider)
     // const isToken = config.targetNet work.l1Token !== undefined
@@ -167,6 +172,7 @@ export default function DepositContent({
             <Deposit
               config={config}
               provider={provider}
+              chainId={chainId}
               l1Balance={l1Balance}
               onCorrectL1={onCorrectL1}
               depositCallback={depositCallback}

--- a/src/components/steps/depositContent.tsx
+++ b/src/components/steps/depositContent.tsx
@@ -62,10 +62,10 @@ export default function DepositContent({
     getChainId()
   }, [provider])
 
-  const onCorrectL1 = useMemo(() => config.l1ChainId === chainId, [
-    chainId,
-    config
-  ])
+  const onCorrectL1 = useMemo(
+    () => config.targetNetwork.l1chainId === chainId,
+    [chainId, config]
+  )
 
   // TODO: refresh balance after successful deposit
   const content = useMemo(() => {
@@ -76,13 +76,15 @@ export default function DepositContent({
             Balance on {network}: {ethers.utils.formatUnits(l1Balance, 18)} ETH
           </div>
         ) : (
-          <Alert
-            style={{ backgroundColor: 'inherit', paddingLeft: 0 }}
-            severity='warning'
-          >
-            You are currently on {network}, please switch to{' '}
-            {ethChains[config.l1ChainId]} to deposit
-          </Alert>
+          config.targetNetwork.l1chainId && (
+            <Alert
+              style={{ backgroundColor: 'inherit', paddingLeft: 0 }}
+              severity='warning'
+            >
+              You are currently on {network}, please switch to{' '}
+              {ethChains[config.targetNetwork.l1chainId]} to deposit
+            </Alert>
+          )
         )}
 
         <div>

--- a/src/components/steps/depositContent.tsx
+++ b/src/components/steps/depositContent.tsx
@@ -86,6 +86,7 @@ export default function DepositContent({
     [config]
   )
 
+  // revisit bridge urls to match deposit function (e.g. bridge currently points to mainnet but all networks are testnets)
   const bridgeLink = useMemo(() => config.targetNetwork.bridgeUrl, [config])
 
   // reload if Chain changed

--- a/src/components/steps/finished.tsx
+++ b/src/components/steps/finished.tsx
@@ -2,12 +2,33 @@ import React from 'react'
 
 import Base from '../baseContent'
 import { Config } from '../../types'
+import { makeStyles } from '@material-ui/core'
+
+const useStyles = makeStyles(() => ({
+  logoWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: 60
+  },
+  icon: {
+    padding: 10
+  }
+}))
 
 export default function WelcomeModal({ config }: { config: Config }) {
+  const classes = useStyles()
+  const sorbetLogo = <img height={120} src='https://i.imgur.com/Q6k8YyH.png' />
   return (
     <Base
       title={`You're all set`}
-      content={`Enjoy your ride with ${config.targetNetwork.name} 🚀`}
+      content={
+        <div>
+          Enjoy your ride with {config.targetNetwork.name} 🚀
+          <div className={classes.logoWrapper}>{sorbetLogo}</div>
+        </div>
+      }
+      //
     />
   )
 }

--- a/src/constant/networks.ts
+++ b/src/constant/networks.ts
@@ -52,17 +52,18 @@ export const Sokol: Network = {
 }
 
 export const Matic: Network = {
-  name: 'Matic',
-  rpcUrls: ['https://rpc-mainnet.maticvigil.com/'],
-  blockExplorerUrl: 'https://explorer.matic.network/',
+  name: 'Matic - Mumbai Testnet',
+  rpcUrls: ['https://rpc-mumbai.matic.today'],
+  blockExplorerUrl: 'https://mumbai-explorer.matic.today',
   nativeCurrency: {
     name: 'Matic',
     symbol: 'MATIC',
     decimals: 18
   },
-  chainId: 137,
+  chainId: 80001,
   img: 'https://i.imgur.com/RNmUy9P.png',
-  bridgeUrl: 'https://wallet.matic.network/bridge/'
+  bridgeUrl: 'https://wallet.matic.network/bridge/',
+  depositNativeToken: depositUtil.depositMaticTestnet
 }
 
 export const Avalanche: Network = {

--- a/src/constant/networks.ts
+++ b/src/constant/networks.ts
@@ -51,7 +51,7 @@ export const Sokol: Network = {
   chainId: 77
 }
 
-export const Matic: Network = {
+export const MaticTestnet: Network = {
   name: 'Matic - Mumbai Testnet',
   rpcUrls: ['https://rpc-mumbai.matic.today'],
   blockExplorerUrl: 'https://mumbai-explorer.matic.today',
@@ -67,6 +67,23 @@ export const Matic: Network = {
   l1chainId: 5, // Goerli
   depositNativeToken: depositUtil.depositETHMaticTestnet,
   depositToken: depositUtil.depositTokenMaticTestnet
+}
+
+export const Matic: Network = {
+  name: 'Matic',
+  rpcUrls: ['https://rpc-mainnet.maticvigil.com/'],
+  blockExplorerUrl: 'https://explorer.matic.network/',
+  nativeCurrency: {
+    name: 'Matic',
+    symbol: 'MATIC',
+    decimals: 18
+  },
+  chainId: 137,
+  img: 'https://i.imgur.com/RNmUy9P.png',
+  bridgeUrl: 'https://wallet.matic.network/bridge/',
+
+  l1chainId: 1,
+  depositNativeToken: depositUtil.depositETHMatic
 }
 
 export const Avalanche: Network = {

--- a/src/constant/networks.ts
+++ b/src/constant/networks.ts
@@ -1,5 +1,6 @@
 import { Network } from '../types'
 import * as depositUtil from '../utils/deposit'
+import { addresses } from '../contracts'
 
 // TODO probably a good idea to combine this with rest of chains below
 export const ethChains = {
@@ -28,7 +29,9 @@ export const Binance: Network = {
   l1Token: {
     address: '0xB8c77482e45F1F44dE1745F52C74426C631bDD52',
     symbol: 'BNB',
-    decimals: 18
+    decimals: 18,
+    // todo: add spender address
+    spender: ''
   }
 }
 
@@ -47,7 +50,9 @@ export const xDai: Network = {
   l1Token: {
     address: '0x6b175474e89094c44da98b954eedeac495271d0f',
     symbol: 'DAI',
-    decimals: 18
+    decimals: 18,
+    // todo: add spender address
+    spender: ''
   },
   img: 'https://i.imgur.com/qDNpwXw.png',
   bridgeUrl: 'https://bridge.xdaichain.com/'
@@ -82,7 +87,8 @@ export const MaticTestnet: Network = {
   l1Token: {
     symbol: 'MATIC',
     decimals: 18,
-    address: '0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae'
+    address: '0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae',
+    spender: addresses.maticDepositProxyGoerli
   },
   depositETH: depositUtil.depositETHMaticTestnet,
   depositToken: depositUtil.depositTokenMaticTestnet
@@ -105,7 +111,8 @@ export const Matic: Network = {
   l1Token: {
     symbol: 'MATIC',
     decimals: 18,
-    address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0'
+    address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
+    spender: addresses.maticDepositProxy
   },
   depositETH: depositUtil.depositETHMatic,
   depositToken: depositUtil.depositTokenMatic

--- a/src/constant/networks.ts
+++ b/src/constant/networks.ts
@@ -22,7 +22,14 @@ export const Binance: Network = {
   },
   chainId: 56,
   img: 'https://i.imgur.com/Jcs4TTC.png',
-  bridgeUrl: 'https://www.binance.org/en/bridge'
+  bridgeUrl: 'https://www.binance.org/en/bridge',
+
+  l1chainId: 1,
+  l1Token: {
+    address: '0xB8c77482e45F1F44dE1745F52C74426C631bDD52',
+    symbol: 'BNB',
+    decimals: 18
+  }
 }
 
 export const xDai: Network = {
@@ -35,6 +42,13 @@ export const xDai: Network = {
     decimals: 18
   },
   chainId: 100,
+
+  l1chainId: 1,
+  l1Token: {
+    address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+    symbol: 'DAI',
+    decimals: 18
+  },
   img: 'https://i.imgur.com/qDNpwXw.png',
   bridgeUrl: 'https://bridge.xdaichain.com/'
 }
@@ -65,7 +79,12 @@ export const MaticTestnet: Network = {
   bridgeUrl: 'https://wallet.matic.network/bridge/',
 
   l1chainId: 5, // Goerli
-  depositNativeToken: depositUtil.depositETHMaticTestnet,
+  l1Token: {
+    symbol: 'MATIC',
+    decimals: 18,
+    address: '0x499d11E0b6eAC7c0593d8Fb292DCBbF815Fb29Ae'
+  },
+  depositETH: depositUtil.depositETHMaticTestnet,
   depositToken: depositUtil.depositTokenMaticTestnet
 }
 
@@ -83,7 +102,12 @@ export const Matic: Network = {
   bridgeUrl: 'https://wallet.matic.network/bridge/',
 
   l1chainId: 1,
-  depositNativeToken: depositUtil.depositETHMatic,
+  l1Token: {
+    symbol: 'MATIC',
+    decimals: 18,
+    address: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0'
+  },
+  depositETH: depositUtil.depositETHMatic,
   depositToken: depositUtil.depositTokenMatic
 }
 
@@ -124,7 +148,7 @@ export const ArbitrumTestnet: Network = {
   bridgeUrl: 'https://bridge.arbitrum.io/',
 
   l1chainId: 42,
-  depositNativeToken: depositUtil.depositArbitrumTestnet
+  depositETH: depositUtil.depositArbitrumTestnet
 }
 
 export const OptimismTestnet: Network = {
@@ -135,7 +159,7 @@ export const OptimismTestnet: Network = {
   img: 'https://i.imgur.com/qHBFlSq.png',
 
   l1chainId: 42,
-  depositNativeToken: depositUtil.depositOptimismTestnet
+  depositETH: depositUtil.depositOptimismTestnet
 }
 
 export const OptimismMainnet: Network = {

--- a/src/constant/networks.ts
+++ b/src/constant/networks.ts
@@ -63,7 +63,10 @@ export const Matic: Network = {
   chainId: 80001,
   img: 'https://i.imgur.com/RNmUy9P.png',
   bridgeUrl: 'https://wallet.matic.network/bridge/',
-  depositNativeToken: depositUtil.depositMaticTestnet
+
+  l1chainId: 5, // Goerli
+  depositNativeToken: depositUtil.depositETHMaticTestnet,
+  depositToken: depositUtil.depositTokenMaticTestnet
 }
 
 export const Avalanche: Network = {
@@ -101,6 +104,8 @@ export const ArbitrumTestnet: Network = {
   chainId: 212984383488152,
   img: 'https://i.imgur.com/QJOromM.png',
   bridgeUrl: 'https://bridge.arbitrum.io/',
+
+  l1chainId: 42,
   depositNativeToken: depositUtil.depositArbitrumTestnet
 }
 
@@ -110,6 +115,8 @@ export const OptimismTestnet: Network = {
   blockExplorerUrl: 'https://kovan-l2-explorer.surge.sh',
   chainId: 69,
   img: 'https://i.imgur.com/qHBFlSq.png',
+
+  l1chainId: 42,
   depositNativeToken: depositUtil.depositOptimismTestnet
 }
 

--- a/src/constant/networks.ts
+++ b/src/constant/networks.ts
@@ -83,7 +83,8 @@ export const Matic: Network = {
   bridgeUrl: 'https://wallet.matic.network/bridge/',
 
   l1chainId: 1,
-  depositNativeToken: depositUtil.depositETHMatic
+  depositNativeToken: depositUtil.depositETHMatic,
+  depositToken: depositUtil.depositTokenMatic
 }
 
 export const Avalanche: Network = {

--- a/src/contracts/abis.ts
+++ b/src/contracts/abis.ts
@@ -1,11 +1,13 @@
 import abiArbitrumKovan4 from './abis/arbitrum-Inbox-Kovan-4.json'
 import abiOptimismKovan2 from './abis/optimism-OVM_L1ETHGateway-Kovan-2.json'
 import abiMaticMumbai from './abis/matic-RootChainManager-Mumbai.json'
+import erc20 from './abis/erc20.json'
 
 const abis = {
   abiArbitrumKovan4: abiArbitrumKovan4,
   abiOptimismKovan2: abiOptimismKovan2,
-  abiMaticMumbai: abiMaticMumbai
+  abiMaticMumbai: abiMaticMumbai,
+  erc20
 }
 
 export default abis

--- a/src/contracts/abis.ts
+++ b/src/contracts/abis.ts
@@ -1,9 +1,11 @@
 import abiArbitrumKovan4 from './abis/arbitrum-Inbox-Kovan-4.json'
 import abiOptimismKovan2 from './abis/optimism-OVM_L1ETHGateway-Kovan-2.json'
+import abiMaticMumbai from './abis/matic-RootChainManager-Mumbai.json'
 
 const abis = {
   abiArbitrumKovan4: abiArbitrumKovan4,
-  abiOptimismKovan2: abiOptimismKovan2
+  abiOptimismKovan2: abiOptimismKovan2,
+  abiMaticMumbai: abiMaticMumbai
 }
 
 export default abis

--- a/src/contracts/abis/erc20.json
+++ b/src/contracts/abis/erc20.json
@@ -1,0 +1,222 @@
+[
+  {
+      "constant": true,
+      "inputs": [],
+      "name": "name",
+      "outputs": [
+          {
+              "name": "",
+              "type": "string"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": false,
+      "inputs": [
+          {
+              "name": "_spender",
+              "type": "address"
+          },
+          {
+              "name": "_value",
+              "type": "uint256"
+          }
+      ],
+      "name": "approve",
+      "outputs": [
+          {
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [],
+      "name": "totalSupply",
+      "outputs": [
+          {
+              "name": "",
+              "type": "uint256"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": false,
+      "inputs": [
+          {
+              "name": "_from",
+              "type": "address"
+          },
+          {
+              "name": "_to",
+              "type": "address"
+          },
+          {
+              "name": "_value",
+              "type": "uint256"
+          }
+      ],
+      "name": "transferFrom",
+      "outputs": [
+          {
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [],
+      "name": "decimals",
+      "outputs": [
+          {
+              "name": "",
+              "type": "uint8"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [
+          {
+              "name": "_owner",
+              "type": "address"
+          }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+          {
+              "name": "balance",
+              "type": "uint256"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [],
+      "name": "symbol",
+      "outputs": [
+          {
+              "name": "",
+              "type": "string"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "constant": false,
+      "inputs": [
+          {
+              "name": "_to",
+              "type": "address"
+          },
+          {
+              "name": "_value",
+              "type": "uint256"
+          }
+      ],
+      "name": "transfer",
+      "outputs": [
+          {
+              "name": "",
+              "type": "bool"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+  },
+  {
+      "constant": true,
+      "inputs": [
+          {
+              "name": "_owner",
+              "type": "address"
+          },
+          {
+              "name": "_spender",
+              "type": "address"
+          }
+      ],
+      "name": "allowance",
+      "outputs": [
+          {
+              "name": "",
+              "type": "uint256"
+          }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+  },
+  {
+      "payable": true,
+      "stateMutability": "payable",
+      "type": "fallback"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "name": "owner",
+              "type": "address"
+          },
+          {
+              "indexed": true,
+              "name": "spender",
+              "type": "address"
+          },
+          {
+              "indexed": false,
+              "name": "value",
+              "type": "uint256"
+          }
+      ],
+      "name": "Approval",
+      "type": "event"
+  },
+  {
+      "anonymous": false,
+      "inputs": [
+          {
+              "indexed": true,
+              "name": "from",
+              "type": "address"
+          },
+          {
+              "indexed": true,
+              "name": "to",
+              "type": "address"
+          },
+          {
+              "indexed": false,
+              "name": "value",
+              "type": "uint256"
+          }
+      ],
+      "name": "Transfer",
+      "type": "event"
+  }
+]

--- a/src/contracts/abis/matic-RootChainManager-Mumbai.json
+++ b/src/contracts/abis/matic-RootChainManager-Mumbai.json
@@ -1,0 +1,482 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "userAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address payable",
+        "name": "relayerAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "functionSignature",
+        "type": "bytes"
+      }
+    ],
+    "name": "MetaTransactionExecuted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "tokenType",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "predicateAddress",
+        "type": "address"
+      }
+    ],
+    "name": "PredicateRegistered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "rootToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "childToken",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "tokenType",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TokenMapped",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "DEPOSIT",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ERC712_VERSION",
+    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ETHER_ADDRESS",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAPPER_ROLE",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAP_TOKEN",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "checkpointManagerAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "childChainManagerAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "childToRootToken",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "depositEtherFor",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "address", "name": "rootToken", "type": "address" },
+      { "internalType": "bytes", "name": "depositData", "type": "bytes" }
+    ],
+    "name": "depositFor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "userAddress", "type": "address" },
+      {
+        "internalType": "bytes",
+        "name": "functionSignature",
+        "type": "bytes"
+      },
+      { "internalType": "bytes32", "name": "sigR", "type": "bytes32" },
+      { "internalType": "bytes32", "name": "sigS", "type": "bytes32" },
+      { "internalType": "uint8", "name": "sigV", "type": "uint8" }
+    ],
+    "name": "executeMetaTransaction",
+    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes", "name": "inputData", "type": "bytes" }
+    ],
+    "name": "exit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getChainId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getDomainSeperator",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "getNonce",
+    "outputs": [
+      { "internalType": "uint256", "name": "nonce", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "uint256", "name": "index", "type": "uint256" }
+    ],
+    "name": "getRoleMember",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
+    ],
+    "name": "getRoleMemberCount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "hasRole",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initializeEIP712",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "rootToken", "type": "address" },
+      { "internalType": "address", "name": "childToken", "type": "address" },
+      { "internalType": "bytes32", "name": "tokenType", "type": "bytes32" }
+    ],
+    "name": "mapToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "processedExits",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "tokenType", "type": "bytes32" },
+      {
+        "internalType": "address",
+        "name": "predicateAddress",
+        "type": "address"
+      }
+    ],
+    "name": "registerPredicate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "rootToken", "type": "address" },
+      { "internalType": "address", "name": "childToken", "type": "address" },
+      { "internalType": "bytes32", "name": "tokenType", "type": "bytes32" }
+    ],
+    "name": "remapToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "rootToChildToken",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newCheckpointManager",
+        "type": "address"
+      }
+    ],
+    "name": "setCheckpointManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newChildChainManager",
+        "type": "address"
+      }
+    ],
+    "name": "setChildChainManagerAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newStateSender",
+        "type": "address"
+      }
+    ],
+    "name": "setStateSender",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "setupContractId",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stateSenderAddress",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "tokenToType",
+    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "typeToPredicate",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/src/contracts/abis/matic-RootChainManager-Mumbai.json
+++ b/src/contracts/abis/matic-RootChainManager-Mumbai.json
@@ -1,482 +1,368 @@
 [
   {
-    "anonymous": false,
+    "constant": false,
     "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "userAddress",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address payable",
-        "name": "relayerAddress",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "functionSignature",
-        "type": "bytes"
-      }
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "address", "name": "_user", "type": "address" },
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
     ],
-    "name": "MetaTransactionExecuted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "tokenType",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "predicateAddress",
-        "type": "address"
-      }
-    ],
-    "name": "PredicateRegistered",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "previousAdminRole",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "newAdminRole",
-        "type": "bytes32"
-      }
-    ],
-    "name": "RoleAdminChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      }
-    ],
-    "name": "RoleGranted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      }
-    ],
-    "name": "RoleRevoked",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "rootToken",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "childToken",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "tokenType",
-        "type": "bytes32"
-      }
-    ],
-    "name": "TokenMapped",
-    "type": "event"
-  },
-  {
-    "inputs": [],
-    "name": "DEFAULT_ADMIN_ROLE",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "DEPOSIT",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ERC712_VERSION",
-    "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ETHER_ADDRESS",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "MAPPER_ROLE",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "MAP_TOKEN",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "checkpointManagerAddress",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "childChainManagerAddress",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "name": "childToRootToken",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "user", "type": "address" }
-    ],
-    "name": "depositEtherFor",
+    "name": "depositERC721ForUser",
     "outputs": [],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "user", "type": "address" },
-      { "internalType": "address", "name": "rootToken", "type": "address" },
-      { "internalType": "bytes", "name": "depositData", "type": "bytes" }
-    ],
-    "name": "depositFor",
-    "outputs": [],
+    "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
+    "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "userAddress", "type": "address" },
-      {
-        "internalType": "bytes",
-        "name": "functionSignature",
-        "type": "bytes"
-      },
-      { "internalType": "bytes32", "name": "sigR", "type": "bytes32" },
-      { "internalType": "bytes32", "name": "sigS", "type": "bytes32" },
-      { "internalType": "uint8", "name": "sigV", "type": "uint8" }
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "_user", "type": "address" },
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" },
+      { "internalType": "bytes", "name": "", "type": "bytes" }
     ],
-    "name": "executeMetaTransaction",
-    "outputs": [{ "internalType": "bytes", "name": "", "type": "bytes" }],
-    "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes", "name": "inputData", "type": "bytes" }
-    ],
-    "name": "exit",
-    "outputs": [],
+    "name": "onERC721Received",
+    "outputs": [{ "internalType": "bytes4", "name": "", "type": "bytes4" }],
+    "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
+    "constant": false,
     "inputs": [],
-    "name": "getChainId",
-    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
-    "stateMutability": "pure",
+    "name": "updateChildChainAndStateSender",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
+    "constant": true,
     "inputs": [],
-    "name": "getDomainSeperator",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "name": "childChain",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
     "stateMutability": "view",
     "type": "function"
   },
   {
+    "constant": false,
     "inputs": [
-      { "internalType": "address", "name": "user", "type": "address" }
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "address", "name": "_user", "type": "address" },
+      { "internalType": "uint256", "name": "_amountOrNFTId", "type": "uint256" }
     ],
-    "name": "getNonce",
+    "name": "transferAssets",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxDepositAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateMaxErc20Deposit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "governance",
     "outputs": [
-      { "internalType": "uint256", "name": "nonce", "type": "uint256" }
+      { "internalType": "contract IGovernance", "name": "", "type": "address" }
     ],
+    "payable": false,
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "registry",
+    "outputs": [
+      { "internalType": "contract Registry", "name": "", "type": "address" }
     ],
-    "name": "getRoleAdmin",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
+    "payable": false,
     "stateMutability": "view",
     "type": "function"
   },
   {
+    "constant": false,
     "inputs": [
-      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
-      { "internalType": "uint256", "name": "index", "type": "uint256" }
+      { "internalType": "address[]", "name": "_tokens", "type": "address[]" },
+      {
+        "internalType": "uint256[]",
+        "name": "_amountOrTokens",
+        "type": "uint256[]"
+      },
+      { "internalType": "address", "name": "_user", "type": "address" }
     ],
-    "name": "getRoleMember",
+    "name": "depositBulk",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "address", "name": "_user", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
+    ],
+    "name": "depositERC20ForUser",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
     "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
     "stateMutability": "view",
     "type": "function"
   },
   {
+    "constant": true,
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
     "inputs": [
-      { "internalType": "bytes32", "name": "role", "type": "bytes32" }
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" }
     ],
-    "name": "getRoleMemberCount",
+    "name": "depositERC20",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rootChain",
+    "outputs": [
+      { "internalType": "contract RootChain", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "depositEther",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "unlock",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "deposits",
+    "outputs": [
+      { "internalType": "bytes32", "name": "depositHash", "type": "bytes32" },
+      { "internalType": "uint256", "name": "createdAt", "type": "uint256" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "_user", "type": "address" },
+      { "internalType": "uint256", "name": "_amount", "type": "uint256" },
+      { "internalType": "bytes", "name": "", "type": "bytes" }
+    ],
+    "name": "tokenFallback",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "stateSender",
+    "outputs": [
+      { "internalType": "contract StateSender", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "locked",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "uint256", "name": "_tokenId", "type": "uint256" }
+    ],
+    "name": "depositERC721",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "maxErc20Deposit",
     "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
     "stateMutability": "view",
     "type": "function"
   },
   {
+    "constant": false,
     "inputs": [
-      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
-      { "internalType": "address", "name": "account", "type": "address" }
+      { "internalType": "address", "name": "_rootChain", "type": "address" }
     ],
-    "name": "grantRole",
+    "name": "updateRootChain",
     "outputs": [],
+    "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
+    "constant": false,
     "inputs": [
-      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
-      { "internalType": "address", "name": "account", "type": "address" }
+      { "internalType": "address", "name": "newOwner", "type": "address" }
     ],
-    "name": "hasRole",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [
-      { "internalType": "address", "name": "_owner", "type": "address" }
-    ],
-    "name": "initialize",
+    "constant": false,
+    "inputs": [],
+    "name": "lock",
     "outputs": [],
+    "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [],
-    "name": "initializeEIP712",
-    "outputs": [],
+    "payable": false,
     "stateMutability": "nonpayable",
-    "type": "function"
+    "type": "constructor"
   },
+  { "payable": true, "stateMutability": "payable", "type": "fallback" },
   {
+    "anonymous": false,
     "inputs": [
-      { "internalType": "address", "name": "rootToken", "type": "address" },
-      { "internalType": "address", "name": "childToken", "type": "address" },
-      { "internalType": "bytes32", "name": "tokenType", "type": "bytes32" }
-    ],
-    "name": "mapToken",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "name": "processedExits",
-    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "tokenType", "type": "bytes32" },
       {
+        "indexed": true,
         "internalType": "address",
-        "name": "predicateAddress",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOrNFTId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositBlockId",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewDepositBlock",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "oldLimit",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "newLimit",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxErc20DepositUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
         "type": "address"
       }
     ],
-    "name": "registerPredicate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "address", "name": "rootToken", "type": "address" },
-      { "internalType": "address", "name": "childToken", "type": "address" },
-      { "internalType": "bytes32", "name": "tokenType", "type": "bytes32" }
-    ],
-    "name": "remapToken",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
-      { "internalType": "address", "name": "account", "type": "address" }
-    ],
-    "name": "renounceRole",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      { "internalType": "bytes32", "name": "role", "type": "bytes32" },
-      { "internalType": "address", "name": "account", "type": "address" }
-    ],
-    "name": "revokeRole",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "name": "rootToChildToken",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newCheckpointManager",
-        "type": "address"
-      }
-    ],
-    "name": "setCheckpointManager",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newChildChainManager",
-        "type": "address"
-      }
-    ],
-    "name": "setChildChainManagerAddress",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newStateSender",
-        "type": "address"
-      }
-    ],
-    "name": "setStateSender",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "setupContractId",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "stateSenderAddress",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "name": "tokenToType",
-    "outputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [{ "internalType": "bytes32", "name": "", "type": "bytes32" }],
-    "name": "typeToPredicate",
-    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  { "stateMutability": "payable", "type": "receive" }
+    "name": "OwnershipTransferred",
+    "type": "event"
+  }
 ]

--- a/src/contracts/addresses.ts
+++ b/src/contracts/addresses.ts
@@ -5,7 +5,7 @@ const addresses = {
   // approve target for matic bridge
 
   // bridge contract
-  maticDepositProxy: '0xA0c68C638235ee32657e8f720a23ceC1bFc77C77',
+  maticDepositProxy: '0x401f6c983ea34274ec46f84d70b31c151321188b',
   maticDepositProxyGoerli: '0x7850ec290A2e2F40B82Ed962eaf30591bb5f5C96'
 }
 

--- a/src/contracts/addresses.ts
+++ b/src/contracts/addresses.ts
@@ -3,10 +3,10 @@ const addresses = {
   optimismBridgeKovan2: '0xf3902e50dA095bD2e954AB320E8eafDA6152dFDa',
 
   // approve target for matic bridge
-  maticERC20Approval: '0x40ec5b33f54e0e8a33a975908c5ba1c14e5bbbdf',
-  maticBridge: '0xA0c68C638235ee32657e8f720a23ceC1bFc77C77',
 
-  maticBridgeMumbai: '0xBbD7cBFA79faee899Eaf900F13C9065bF03B1A74'
+  // bridge contract
+  maticDepositProxy: '0xA0c68C638235ee32657e8f720a23ceC1bFc77C77',
+  maticDepositProxyGoerli: '0x7850ec290A2e2F40B82Ed962eaf30591bb5f5C96'
 }
 
 export default addresses

--- a/src/contracts/addresses.ts
+++ b/src/contracts/addresses.ts
@@ -1,6 +1,7 @@
 const addresses = {
   addressArbitrumKovan4: '0xd71d47ad1b63981e9db8e4a78c0b30170da8a601',
-  addressOptimismKovan2: '0xf3902e50dA095bD2e954AB320E8eafDA6152dFDa'
+  addressOptimismKovan2: '0xf3902e50dA095bD2e954AB320E8eafDA6152dFDa',
+  addressMaticMumbai: '0xBbD7cBFA79faee899Eaf900F13C9065bF03B1A74'
 }
 
 export default addresses

--- a/src/contracts/addresses.ts
+++ b/src/contracts/addresses.ts
@@ -1,7 +1,12 @@
 const addresses = {
-  addressArbitrumKovan4: '0xd71d47ad1b63981e9db8e4a78c0b30170da8a601',
-  addressOptimismKovan2: '0xf3902e50dA095bD2e954AB320E8eafDA6152dFDa',
-  addressMaticMumbai: '0xBbD7cBFA79faee899Eaf900F13C9065bF03B1A74'
+  arbitrumBridgeKovan4: '0xd71d47ad1b63981e9db8e4a78c0b30170da8a601',
+  optimismBridgeKovan2: '0xf3902e50dA095bD2e954AB320E8eafDA6152dFDa',
+
+  // approve target for matic bridge
+  maticERC20Approval: '0x40ec5b33f54e0e8a33a975908c5ba1c14e5bbbdf',
+  maticBridge: '0xA0c68C638235ee32657e8f720a23ceC1bFc77C77',
+
+  maticBridgeMumbai: '0xBbD7cBFA79faee899Eaf900F13C9065bF03B1A74'
 }
 
 export default addresses

--- a/src/sorbetModal.tsx
+++ b/src/sorbetModal.tsx
@@ -18,14 +18,14 @@ import { light, dark } from './style/defaultTheme'
 
 enum Steps {
   Welcome,
-  DepositL1Balance,
+  Deposit,
   SwitchNetwork,
   Finished
 }
 
 export const Sorbet = React.memo(
   ({ config, walletProvider }: { config: Config; walletProvider: any }) => {
-    const [step, setSteps] = useState<Steps>(Steps.Welcome)
+    const [step, setSteps] = useState<Steps>(Steps.Deposit)
 
     // verify config on update
     useEffect(() => {
@@ -44,7 +44,7 @@ export const Sorbet = React.memo(
       switch (step) {
         case Steps.Welcome:
           return <Welcome config={config} />
-        case Steps.DepositL1Balance:
+        case Steps.Deposit:
           return <Deposit config={config} provider={walletProvider} />
         case Steps.SwitchNetwork:
           return (
@@ -80,24 +80,24 @@ export const Sorbet = React.memo(
                   <Button
                     style={{ float: 'right' }}
                     variant={
-                      step === Steps.SwitchNetwork ||
-                      step === Steps.DepositL1Balance
+                      step === Steps.SwitchNetwork || step === Steps.Deposit
                         ? 'outlined'
                         : 'contained'
                     }
                     color='primary'
                     onClick={nextStep}
                   >
-                    {step === Steps.SwitchNetwork ||
-                    step === Steps.DepositL1Balance
+                    {step === Steps.SwitchNetwork || step === Steps.Deposit
                       ? 'Skip'
                       : 'Next'}
                   </Button>
                 )}
                 {step === Steps.Finished && (
                   <Button
+                    color='primary'
                     style={{ float: 'right' }}
                     onClick={() => config.handleClose(false)}
+                    variant='contained'
                   >
                     {' '}
                     Done{' '}

--- a/src/sorbetModal.tsx
+++ b/src/sorbetModal.tsx
@@ -25,7 +25,7 @@ enum Steps {
 
 export const Sorbet = React.memo(
   ({ config, walletProvider }: { config: Config; walletProvider: any }) => {
-    const [step, setSteps] = useState<Steps>(Steps.Deposit)
+    const [step, setSteps] = useState<Steps>(Steps.Welcome)
 
     // verify config on update
     useEffect(() => {

--- a/src/sorbetModal.tsx
+++ b/src/sorbetModal.tsx
@@ -1,4 +1,3 @@
-import { BigNumber, providers, ethers } from 'ethers'
 import React, { useCallback, useEffect, useState, useMemo } from 'react'
 
 import { Config } from './types'
@@ -26,33 +25,12 @@ enum Steps {
 
 export const Sorbet = React.memo(
   ({ config, walletProvider }: { config: Config; walletProvider: any }) => {
-    const [rpcProvider, setRPCProvider] = useState<any | null>(null)
-
-    const [l1Balance, setL1Balance] = useState<BigNumber>(BigNumber.from(0))
-    const [l2Balance, setL2Balance] = useState<BigNumber>(BigNumber.from(0))
-
     const [step, setSteps] = useState<Steps>(Steps.Welcome)
-
-    // const [chainId, setChainId] = useState<number>(0)
-    // const [network, setNetwork] = useState<string>()
 
     // verify config on update
     useEffect(() => {
       verifyConfig(config)
-      const _rpcProvider = new providers.JsonRpcProvider(
-        config.targetNetwork.rpcUrls[0]
-      )
-      setRPCProvider(_rpcProvider)
     }, [config])
-
-    // update L2 balance
-    useEffect(() => {
-      if (!config.checkBalance || !config.address || !rpcProvider) return
-
-      rpcProvider
-        .getBalance(config.address)
-        .then((balance: BigNumber) => setL2Balance(balance))
-    }, [config, rpcProvider])
 
     const nextStep = useCallback(() => {
       setSteps((step) => step + 1)
@@ -62,29 +40,12 @@ export const Sorbet = React.memo(
       setSteps((step) => step - 1)
     }, [])
 
-    useEffect(() => {
-      if (!config.address || !walletProvider) return
-      const web3Provider = new ethers.providers.Web3Provider(walletProvider)
-      web3Provider
-        .getBalance(config.address)
-        .then((balance: BigNumber) => setL1Balance(balance))
-    }, [walletProvider, config])
-
     const content = useMemo(() => {
       switch (step) {
         case Steps.Welcome:
           return <Welcome config={config} />
         case Steps.DepositL1Balance:
-          return (
-            <Deposit
-              config={config}
-              l1Balance={l1Balance}
-              l2Balance={l2Balance}
-              provider={walletProvider}
-              // chainId={chainId}
-              // network={network!}
-            />
-          )
+          return <Deposit config={config} provider={walletProvider} />
         case Steps.SwitchNetwork:
           return (
             <SwitchNetwork
@@ -96,7 +57,7 @@ export const Sorbet = React.memo(
         default:
           return <Finished config={config} />
       }
-    }, [step, config, l2Balance])
+    }, [step, config])
 
     return (
       <ThemeProvider theme={config.darkMode ? dark : light}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,14 +38,16 @@ export type Network = {
   depositNativeToken?: (
     provider: any,
     amount: string,
-    sender: string
+    sender: string,
+    callback?: Function
   ) => Promise<void>
 
   depositToken?: (
     provider: any,
     token: string,
     amount: string,
-    sender: string
+    sender: string,
+    callback?: Function
   ) => Promise<void>
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,7 @@ export type Network = {
     address: string
     symbol: string
     decimals: number
+    spender: string
   }
 
   blockExplorerUrl?: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,14 +28,22 @@ export type Network = {
     decimals: number
   }
 
+  // which network should user depoist from
   l1chainId?: number
+
+  // native token on the L1. (use undefined for ETH)
+  l1Token?: {
+    address: string
+    symbol: string
+    decimals: number
+  }
 
   blockExplorerUrl?: string
   img?: string
   bridgeUrl?: string
 
   // deposit function
-  depositNativeToken?: (
+  depositETH?: (
     provider: any,
     amount: string,
     sender: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,12 +10,6 @@ export type Config = {
   checkBalance?: boolean
   // user's address to check
   address?: string
-  // // Type of L1 token to deposit to L2
-  // depositToken: string
-  // // Amount of L1 token to deposit to L2
-  // depositAmount: string
-  // L1 Network
-  l1ChainId: number
 
   // Dapp name
   dappName: string
@@ -33,11 +27,23 @@ export type Network = {
     name: string
     decimals: number
   }
+
+  l1chainId?: number
+
   blockExplorerUrl?: string
   img?: string
   bridgeUrl?: string
+
+  // deposit function
   depositNativeToken?: (
     provider: any,
+    amount: string,
+    sender: string
+  ) => Promise<void>
+
+  depositToken?: (
+    provider: any,
+    token: string,
     amount: string,
     sender: string
   ) => Promise<void>

--- a/src/utils/basic.ts
+++ b/src/utils/basic.ts
@@ -27,6 +27,9 @@ export async function approve(
     abis.erc20,
     web3Provider.getSigner()
   )
-  const { hash } = await tokenContract.approve(spender, amount, { from: user })
-  if (typeof callback === 'function') provider.once(hash, () => callback())
+  await tokenContract.approve(spender, amount, { from: user })
+  if (typeof callback === 'function')
+    tokenContract.once('Approval', () => {
+      callback()
+    })
 }

--- a/src/utils/basic.ts
+++ b/src/utils/basic.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers'
 
 import { abis } from '../contracts'
 
-export async function getApproval(
+export async function getAllowance(
   provider: any,
   token: string,
   user: string,

--- a/src/utils/basic.ts
+++ b/src/utils/basic.ts
@@ -1,0 +1,32 @@
+import { ethers } from 'ethers'
+
+import { abis } from '../contracts'
+
+export async function getApproval(
+  provider: any,
+  token: string,
+  user: string,
+  spender: string
+) {
+  const web3Provider = new ethers.providers.Web3Provider(provider)
+  const tokenContract = new ethers.Contract(token, abis.erc20, web3Provider)
+  return await tokenContract.allowance(user, spender)
+}
+
+export async function approve(
+  provider: any,
+  token: string,
+  user: string,
+  spender: string,
+  amount: string,
+  callback?: Function
+) {
+  const web3Provider = new ethers.providers.Web3Provider(provider)
+  const tokenContract = new ethers.Contract(
+    token,
+    abis.erc20,
+    web3Provider.getSigner()
+  )
+  const { hash } = await tokenContract.approve(spender, amount, { from: user })
+  if (typeof callback === 'function') provider.once(hash, () => callback())
+}

--- a/src/utils/deposit.ts
+++ b/src/utils/deposit.ts
@@ -5,7 +5,8 @@ import { abis, addresses } from '../contracts'
 export async function depositArbitrumTestnet(
   externalProvider: ethers.providers.ExternalProvider,
   amount: string,
-  sender: string
+  sender: string,
+  callback?: Function
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
@@ -13,16 +14,19 @@ export async function depositArbitrumTestnet(
     abis.abiArbitrumKovan4,
     provider.getSigner()
   )
-  await contract.depositEth(sender, {
+  const { hash } = await contract.depositEth(sender, {
     value: amount,
     from: sender
   })
+
+  if (typeof callback === 'function') provider.once(hash, () => callback())
 }
 
 export async function depositOptimismTestnet(
   externalProvider: ethers.providers.ExternalProvider,
   amount: string,
-  sender: string
+  sender: string,
+  callback?: Function
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
@@ -30,17 +34,20 @@ export async function depositOptimismTestnet(
     abis.abiOptimismKovan2,
     provider.getSigner()
   )
-  await contract.deposit({
+  const { hash } = await contract.deposit({
     from: sender,
     value: amount
   })
+
+  if (typeof callback === 'function') provider.once(hash, () => callback())
 }
 
 // todo: merge depositETHMatic & depositETHMaticTestnet
 export async function depositETHMatic(
   externalProvider: ethers.providers.ExternalProvider,
   amount: string,
-  sender: string
+  sender: string,
+  callback?: Function
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
@@ -48,16 +55,19 @@ export async function depositETHMatic(
     abis.abiMaticMumbai,
     provider.getSigner()
   )
-  await contract.depositEtherFor(sender, {
+  const { hash } = await contract.depositEtherFor(sender, {
     from: sender,
     value: amount
   })
+
+  if (typeof callback === 'function') provider.once(hash, () => callback())
 }
 
 export async function depositETHMaticTestnet(
   externalProvider: ethers.providers.ExternalProvider,
   amount: string,
-  sender: string
+  sender: string,
+  callback?: Function
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
@@ -65,17 +75,20 @@ export async function depositETHMaticTestnet(
     abis.abiMaticMumbai,
     provider.getSigner()
   )
-  await contract.depositEtherFor(sender, {
+  const { hash } = await contract.depositEtherFor(sender, {
     from: sender,
     value: amount
   })
+
+  if (typeof callback === 'function') provider.once(hash, () => callback())
 }
 
 export async function depositTokenMatic(
   externalProvider: ethers.providers.ExternalProvider,
   token: string,
   amount: string,
-  sender: string
+  sender: string,
+  callback?: Function
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
@@ -85,16 +98,19 @@ export async function depositTokenMatic(
   )
   const coder = new ethers.utils.AbiCoder()
   const depositData = coder.encode(['uint256'], [amount])
-  await contract.depositFor(sender, token, depositData, {
+  const { hash } = await contract.depositFor(sender, token, depositData, {
     from: sender
   })
+
+  if (typeof callback === 'function') provider.once(hash, () => callback())
 }
 
 export async function depositTokenMaticTestnet(
   externalProvider: ethers.providers.ExternalProvider,
   token: string,
   amount: string,
-  sender: string
+  sender: string,
+  callback?: Function
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
@@ -104,7 +120,9 @@ export async function depositTokenMaticTestnet(
   )
   const coder = new ethers.utils.AbiCoder()
   const depositData = coder.encode(['uint256'], [amount])
-  await contract.depositFor(sender, token, depositData, {
+  const { hash } = await contract.depositFor(sender, token, depositData, {
     from: sender
   })
+
+  if (typeof callback === 'function') provider.once(hash, () => callback())
 }

--- a/src/utils/deposit.ts
+++ b/src/utils/deposit.ts
@@ -35,3 +35,20 @@ export async function depositOptimismTestnet(
     value: amount
   })
 }
+
+export async function depositMaticTestnet(
+  externalProvider: ethers.providers.ExternalProvider,
+  amount: string,
+  sender: string
+) {
+  const provider = new ethers.providers.Web3Provider(externalProvider)
+  const contract = new ethers.Contract(
+    addresses.addressMaticMumbai,
+    abis.abiMaticMumbai,
+    provider.getSigner()
+  )
+  await contract.depositEtherFor(sender, {
+    from: sender,
+    value: amount
+  })
+}

--- a/src/utils/deposit.ts
+++ b/src/utils/deposit.ts
@@ -9,7 +9,7 @@ export async function depositArbitrumTestnet(
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
-    addresses.addressArbitrumKovan4,
+    addresses.arbitrumBridgeKovan4,
     abis.abiArbitrumKovan4,
     provider.getSigner()
   )
@@ -26,11 +26,29 @@ export async function depositOptimismTestnet(
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
-    addresses.addressOptimismKovan2,
+    addresses.optimismBridgeKovan2,
     abis.abiOptimismKovan2,
     provider.getSigner()
   )
   await contract.deposit({
+    from: sender,
+    value: amount
+  })
+}
+
+// todo: merge depositETHMatic & depositETHMaticTestnet
+export async function depositETHMatic(
+  externalProvider: ethers.providers.ExternalProvider,
+  amount: string,
+  sender: string
+) {
+  const provider = new ethers.providers.Web3Provider(externalProvider)
+  const contract = new ethers.Contract(
+    addresses.maticBridge,
+    abis.abiMaticMumbai,
+    provider.getSigner()
+  )
+  await contract.depositEtherFor(sender, {
     from: sender,
     value: amount
   })
@@ -43,7 +61,7 @@ export async function depositETHMaticTestnet(
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
-    addresses.addressMaticMumbai,
+    addresses.maticBridge,
     abis.abiMaticMumbai,
     provider.getSigner()
   )
@@ -61,10 +79,11 @@ export async function depositTokenMaticTestnet(
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
-    addresses.addressMaticMumbai,
+    addresses.maticBridgeMumbai,
     abis.abiMaticMumbai,
     provider.getSigner()
   )
+  // this is wrong
   const depositData = amount
   await contract.depositFor(sender, token, depositData, {
     from: sender

--- a/src/utils/deposit.ts
+++ b/src/utils/deposit.ts
@@ -51,7 +51,7 @@ export async function depositETHMatic(
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
-    addresses.maticBridge,
+    addresses.maticDepositProxy,
     abis.abiMaticMumbai,
     provider.getSigner()
   )
@@ -71,7 +71,7 @@ export async function depositETHMaticTestnet(
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
-    addresses.maticBridge,
+    addresses.maticDepositProxy,
     abis.abiMaticMumbai,
     provider.getSigner()
   )
@@ -92,7 +92,7 @@ export async function depositTokenMatic(
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
-    addresses.maticBridge,
+    addresses.maticDepositProxy,
     abis.abiMaticMumbai,
     provider.getSigner()
   )
@@ -114,7 +114,7 @@ export async function depositTokenMaticTestnet(
 ) {
   const provider = new ethers.providers.Web3Provider(externalProvider)
   const contract = new ethers.Contract(
-    addresses.maticBridgeMumbai,
+    addresses.maticDepositProxyGoerli,
     abis.abiMaticMumbai,
     provider.getSigner()
   )

--- a/src/utils/deposit.ts
+++ b/src/utils/deposit.ts
@@ -98,7 +98,7 @@ export async function depositTokenMatic(
   )
   const coder = new ethers.utils.AbiCoder()
   const depositData = coder.encode(['uint256'], [amount])
-  const { hash } = await contract.depositFor(sender, token, depositData, {
+  const { hash } = await contract.depositFor(token, sender, depositData, {
     from: sender
   })
 
@@ -118,9 +118,7 @@ export async function depositTokenMaticTestnet(
     abis.abiMaticMumbai,
     provider.getSigner()
   )
-  const coder = new ethers.utils.AbiCoder()
-  const depositData = coder.encode(['uint256'], [amount])
-  const { hash } = await contract.depositFor(sender, token, depositData, {
+  const { hash } = await contract.depositERC20ForUser(token, sender, amount, {
     from: sender
   })
 

--- a/src/utils/deposit.ts
+++ b/src/utils/deposit.ts
@@ -96,9 +96,7 @@ export async function depositTokenMatic(
     abis.abiMaticMumbai,
     provider.getSigner()
   )
-  const coder = new ethers.utils.AbiCoder()
-  const depositData = coder.encode(['uint256'], [amount])
-  const { hash } = await contract.depositFor(token, sender, depositData, {
+  const { hash } = await contract.depositERC20ForUser(token, sender, amount, {
     from: sender
   })
 

--- a/src/utils/deposit.ts
+++ b/src/utils/deposit.ts
@@ -71,6 +71,25 @@ export async function depositETHMaticTestnet(
   })
 }
 
+export async function depositTokenMatic(
+  externalProvider: ethers.providers.ExternalProvider,
+  token: string,
+  amount: string,
+  sender: string
+) {
+  const provider = new ethers.providers.Web3Provider(externalProvider)
+  const contract = new ethers.Contract(
+    addresses.maticBridge,
+    abis.abiMaticMumbai,
+    provider.getSigner()
+  )
+  const coder = new ethers.utils.AbiCoder()
+  const depositData = coder.encode(['uint256'], [amount])
+  await contract.depositFor(sender, token, depositData, {
+    from: sender
+  })
+}
+
 export async function depositTokenMaticTestnet(
   externalProvider: ethers.providers.ExternalProvider,
   token: string,
@@ -83,8 +102,8 @@ export async function depositTokenMaticTestnet(
     abis.abiMaticMumbai,
     provider.getSigner()
   )
-  // this is wrong
-  const depositData = amount
+  const coder = new ethers.utils.AbiCoder()
+  const depositData = coder.encode(['uint256'], [amount])
   await contract.depositFor(sender, token, depositData, {
     from: sender
   })

--- a/src/utils/deposit.ts
+++ b/src/utils/deposit.ts
@@ -36,7 +36,7 @@ export async function depositOptimismTestnet(
   })
 }
 
-export async function depositMaticTestnet(
+export async function depositETHMaticTestnet(
   externalProvider: ethers.providers.ExternalProvider,
   amount: string,
   sender: string
@@ -50,5 +50,23 @@ export async function depositMaticTestnet(
   await contract.depositEtherFor(sender, {
     from: sender,
     value: amount
+  })
+}
+
+export async function depositTokenMaticTestnet(
+  externalProvider: ethers.providers.ExternalProvider,
+  token: string,
+  amount: string,
+  sender: string
+) {
+  const provider = new ethers.providers.Web3Provider(externalProvider)
+  const contract = new ethers.Contract(
+    addresses.addressMaticMumbai,
+    abis.abiMaticMumbai,
+    provider.getSigner()
+  )
+  const depositData = amount
+  await contract.depositFor(sender, token, depositData, {
+    from: sender
   })
 }


### PR DESCRIPTION
## Add deposit token logic 
* for chains that requires depositing a L1 token that's not **eth**, there should be a `depositToken` function and `l1Token` object specified in the config. (eg, Matic, xDai, BSC.. etc)
* need to specify the `spender` address in the config as well, so we can check their approval before making the deposit call. 